### PR TITLE
Agregar los archivos terraform iniciales

### DIFF
--- a/iac/main.tf
+++ b/iac/main.tf
@@ -5,9 +5,9 @@ provider "kubernetes" {
 resource "kubernetes_deployment" "app" {
     
   metadata {
-    name = "miapp"
+    name = "nginx-deployment"
     labels = {
-      app = "miapp"
+      app = "nginx-app-deployment"
     }
   }
 
@@ -15,18 +15,18 @@ resource "kubernetes_deployment" "app" {
     replicas = 2
     selector {
       match_labels = {
-        app = "miapp"
+        app = "nginx-app"
       }
     }
     template {
       metadata {
         labels = {
-          app = "miapp"
+          app = "nginx-app"
         }
       }
       spec {
         container {
-          name  = "miapp"
+          name  = "web-contenedor"
           image = "nginx:1.25"
           port {
             container_port = 80
@@ -43,7 +43,7 @@ resource "kubernetes_service" "app" {
   }
   spec {
     selector = {
-      app = kubernetes_deployment.app.metadata[0].labels.app
+      app = "nginx-app"
     }
     port {
       port        = 80

--- a/iac/main.tf
+++ b/iac/main.tf
@@ -1,0 +1,54 @@
+provider "kubernetes" {
+  config_path = "~/.kube/config"
+}
+
+resource "kubernetes_deployment" "app" {
+    
+  metadata {
+    name = "miapp"
+    labels = {
+      app = "miapp"
+    }
+  }
+
+  spec {
+    replicas = 2
+    selector {
+      match_labels = {
+        app = "miapp"
+      }
+    }
+    template {
+      metadata {
+        labels = {
+          app = "miapp"
+        }
+      }
+      spec {
+        container {
+          name  = "miapp"
+          image = "nginx:1.25"
+          port {
+            container_port = 80
+          }
+        }
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "app" {
+  metadata {
+    name = "miapp-service"
+  }
+  spec {
+    selector = {
+      app = kubernetes_deployment.app.metadata[0].labels.app
+    }
+    port {
+      port        = 80
+      target_port = 80
+    }
+    type = "ClusterIP"
+  }
+}


### PR DESCRIPTION
## Cambios realizados

- main.tf define una infraestructura mínima en Kubernetes usando Terraform para pruebas locales con Minikube.
- Se crea un Deployment llamado miapp con 2 réplicas del contenedor nginx:1.25. 
- Se define un Service (ClusterIP) llamado miapp-service, que expone el Deployment internamente dentro del clúster, permite acceder de forma estable al conjunto de pods desde dentro del clúster.
- El Service redirige el tráfico al puerto 80 de todos los Pods que tengan la etiqueta definida

## Issues relacionados
- #1