### PR TITLE
Configuración de un "pipeline de CI" local y script de remediación de drift

### DIFF
--- a/scripts/drift_remediation.sh
+++ b/scripts/drift_remediation.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+PYTHON="python"
+DIR_RAIZ="$(cd "$(dirname "$0")/.." && pwd)"
+DIR_IAC="${DIR_RAIZ}/iac"
+DIR_SCRIPTS="${DIR_RAIZ}/scripts"
+
+# Remediación con terraform apply
+cd "$DIR_IAC"
+terraform apply -auto-approve > /dev/null
+
+echo "Remediación realizada. Verificando nuevamente..."
+# Se verifica nuevamente con el script comparador
+cd "$DIR_SCRIPTS"
+$PYTHON state_comparador.py
+if [ $? -ne 0 ]; then
+    echo "No se pudo remediar el drift correctamente. "
+    exit 1
+else
+    echo "Drift remediado exitosamente."
+    exit 0
+fi

--- a/scripts/pipeline.sh
+++ b/scripts/pipeline.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+PYTHON="python"
+DIR_RAIZ="$(cd "$(dirname "$0")/.." && pwd)"
+DIR_IAC="${DIR_RAIZ}/iac"
+DIR_SCRIPTS="${DIR_RAIZ}/scripts"
+
+# Se despliega localmente la infraestructura
+(
+    cd $DIR_IAC
+    echo "Inicializando y aplicando infraestuctura definida en los archivos de terraform..."
+    terraform init > /dev/null
+    terraform apply -auto-approve > /dev/null
+)
+
+# Se genera un drift manualmente
+echo "Generando drift..."
+kubectl scale deployment nginx-deployment --replicas=5 > /dev/null
+
+# Se verifica si hay drift o no
+cd "$DIR_SCRIPTS"
+echo "Ejecutando comparador de estados..."
+$PYTHON state_comparador.py
+if [ $? -ne 0 ]; then
+    echo "Se ha detectado drift. Iniciando remediación..."
+    echo ""
+    bash "${DIR_SCRIPTS}/drift_remediation.sh"
+    exit 1
+else    
+    echo "No se ha detectado drift".
+    exit 0
+fi


### PR DESCRIPTION
## Cambios realizados
- Se creó un script bash `pipeline.sh` que simula un pipeline CI. Este script despliega la infraestructura, introduce un drift manualmente, ejecuta el comparador de estados y detecta si hay un drift.
- Si es que hay un drift en el script anterior, se ejecuta el script de remediación `drift_remediation.sh`

## Issues relacionados
- #13 
- #14 