### PR TITLE
Creación de prueba de contrato para outputs de módulos terraform

### DIFF
--- a/contracts/tf_output_schema.json
+++ b/contracts/tf_output_schema.json
@@ -1,0 +1,56 @@
+{
+    "type": "object",
+    "properties": {
+        "deployment_name": {
+            "type": "string",
+            "minLength": 1
+        },
+        "deployment_replicas": {
+            "type": "integer",
+            "minimum": 1
+        },
+        "container_image": {
+            "type": "string",
+            "pattern": "^[\\w\\-/]+:[\\d\\.]+$"
+        },
+        "container_port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "service_name": {
+            "type": "string",
+            "minLength": 1
+        },
+        "service_port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "service_target_port": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "service_type": {
+            "type": "string",
+            "enum": ["ClusterIP", "NodePort", "LoadBalancer"]
+        },
+        "service_cluster_ip": {
+            "type": "string",
+            "format": "ipv4"
+        }
+    },
+    "required": [
+        "deployment_name",
+        "deployment_replicas",
+        "container_image",
+        "container_port",
+        "service_name",
+        "service_port",
+        "service_target_port",
+        "service_type",
+        "service_cluster_ip"
+    ],
+    "additionalProperties": false
+}

--- a/iac/outputs.tf
+++ b/iac/outputs.tf
@@ -1,0 +1,45 @@
+
+output "deployment_name" {
+    description = "Nombre del Deployment Kubernetes"
+    value       = kubernetes_deployment.app.metadata[0].name
+}
+
+output "deployment_replicas" {
+    description = "Número de réplicas del Deployment"
+    value       = tonumber(kubernetes_deployment.app.spec[0].replicas)
+}
+
+output "container_image" {
+    description = "Imagen usada en el contenedor del Deployment"
+    value       = kubernetes_deployment.app.spec[0].template[0].spec[0].container[0].image
+}
+
+output "container_port" {
+    description = "Puerto expuesto por el contenedor del Deployment"
+    value       = tonumber(kubernetes_deployment.app.spec[0].template[0].spec[0].container[0].port[0].container_port)
+}
+
+output "service_name" {
+    description = "Nombre del Service Kubernetes"
+    value       = kubernetes_service.app.metadata[0].name
+}
+
+output "service_port" {
+    description = "Puerto configurado en el Service"
+    value       = tonumber(kubernetes_service.app.spec[0].port[0].port)
+}
+
+output "service_target_port" {
+    description = "Target port configurado en el Service"
+    value       = tonumber(kubernetes_service.app.spec[0].port[0].target_port)
+}
+
+output "service_type" {
+    description = "Tipo de Service (ClusterIP, NodePort, etc.)"
+    value       = kubernetes_service.app.spec[0].type
+}
+
+output "service_cluster_ip" {
+    description = "Cluster IP asignada al Service"
+    value       = kubernetes_service.app.spec[0].cluster_ip
+}

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,0 +1,27 @@
+import json
+import subprocess
+import pytest
+from jsonschema import validate, ValidationError
+
+SCHEMA_PATH = "contracts/tf_output_schema.json"
+
+@pytest.fixture(scope="module")
+def tf_outputs():
+    result = subprocess.run(
+        ["terraform", "output", "-json"],
+        cwd="iac",
+        capture_output=True, text=True, check=True
+    )
+    raw = json.loads(result.stdout)
+    return {k: v["value"] for k, v in raw.items()}
+
+def test_outputs_contract(tf_outputs):
+    # Cargamos el JSON Schema
+    with open(SCHEMA_PATH) as f:
+        schema = json.load(f)
+
+    # Validamos los outputs reales contra el esquema
+    try:
+        validate(instance=tf_outputs, schema=schema)
+    except ValidationError as e:
+        pytest.fail(f"Contrato de outputs inválido: {e.message}")


### PR DESCRIPTION
-Se agrega outputs.tf que define los outputs para Kubernetes Deployment y Service
-Se agrega JSON Schema para validar el terraform output
-Se agrega el pytest prueba de contrato para terraform output